### PR TITLE
Accept arrays as options for OptionsConfigs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.bundle/
 /.yardoc
 /_yardoc/
+/vendor/
 /coverage/
 /doc/
 /pkg/

--- a/lib/view_component/storybook/controls/options_config.rb
+++ b/lib/view_component/storybook/controls/options_config.rb
@@ -15,10 +15,25 @@ module ViewComponent
         def initialize(type, component, param, options, default_value, name: nil)
           super(component, param, default_value, name: name)
           @type = type
-          @options = options
+          @options = expand_options(options)
         end
 
         private
+
+        def expand_options(options)
+          case options
+          when Hash
+            options
+          when Array
+            array_to_hash(options)
+          else
+            raise "Options must be either an Array or Hash"
+          end
+        end
+
+        def array_to_hash(arr)
+          arr.each_with_object({}) { |k, h| h[k] = k }
+        end
 
         def csf_control_params
           super.merge(options: options)

--- a/spec/dummy/test/components/stories/kitchen_sink_component_stories.rb
+++ b/spec/dummy/test/components/stories/kitchen_sink_component_stories.rb
@@ -10,7 +10,7 @@ class KitchenSinkComponentStories < ViewComponent::Storybook::Stories
       number_pets 2
       sports %w[football baseball]
       select(:favorite_food, { hot_dog: "Hot Dog", pizza: "Pizza", burgers: "Burgers", ice_cream: "Ice Cream" }, "Ice Cream")
-      radio(:mood, { happy: "Happy", sad: "Sad", angry: "Angry", content: "Content" }, "Happy")
+      radio(:mood, ["Happy", "Sad", "Angry", "Content"], "Happy")
       other_things(hair: "Brown", eyes: "Blue")
     end
   end

--- a/spec/view_component/storybook/controls/options_config_spec.rb
+++ b/spec/view_component/storybook/controls/options_config_spec.rb
@@ -15,6 +15,19 @@ RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
 
         let(:csf_arg_type_control_overrides) { { options: options } }
       end
+
+      context "using array options" do
+        let(:options) { ["red", "blue","yellow"] }
+
+        it_behaves_like "a controls config" do
+          subject { described_class.new(type, component, param, options, value, name: name) }
+
+          let(:value) { "blue" }
+          let(:param_value) { "blue" }
+
+          let(:csf_arg_type_control_overrides) { { options: { "red" => "red", "blue" => "blue", "yellow" => "yellow" } } }
+        end
+      end
     end
   end
 

--- a/spec/view_component/storybook/stories_spec.rb
+++ b/spec/view_component/storybook/stories_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ViewComponent::Storybook::Stories do
               mood: {
                 control: {
                   type: :radio,
-                  options: { happy: "Happy", sad: "Sad", angry: "Angry", content: "Content" },
+                  options: { "Happy" => "Happy", "Sad" => "Sad", "Angry" => "Angry", "Content" => "Content" },
                 },
                 name: "Mood"
               },


### PR DESCRIPTION
I've found myself using a lot of array => Hash conversions, so this could help a lot!
https://github.com/primer/view_components/pull/51

## Use case

It is quite normal to have a constant indicating which options are valid such as
https://github.com/primer/view_components/blob/main/app/components/primer/button_component.rb#L25-L26

Building stories using those constants instead of enumerating them all over again is quite helpful, since if we change the component, the story doesn't need to change.