### PR TITLE
Add a wildcard CORS header

### DIFF
--- a/app/controllers/view_component/storybook/stories_controller.rb
+++ b/app/controllers/view_component/storybook/stories_controller.rb
@@ -10,6 +10,7 @@ module ViewComponent
 
       before_action :find_stories, :find_story, only: :show
       before_action :require_local!, unless: :show_stories?
+      before_action :add_wildcard_cors_header, only: :show
 
       content_security_policy(false) if respond_to?(:content_security_policy)
 
@@ -41,6 +42,10 @@ module ViewComponent
         story_name = params[:story]
         @story = @stories.find_story(story_name)
         head :not_found unless @story
+      end
+
+      def add_wildcard_cors_header
+        headers['Access-Control-Allow-Origin'] = '*'
       end
     end
   end


### PR DESCRIPTION
`ViewComponent::Storybook::StoriesController` was causing a CORS error in Storybook when I tried to set this up locally:

<img width="1658" alt="Screen Shot 2021-03-06 at 5 29 16 PM" src="https://user-images.githubusercontent.com/123345/110222636-a485d200-7ea1-11eb-9e6d-d8e6c6661e5b.png">

I think it's sane to add a wildcard CORS header to this controller, so that's what I did in this PR.

LMK if I shouldn't solve the problem this way or if there's a better solution that doesn't require a code change.