### PR TITLE
Custom stories title

### DIFF
--- a/lib/view_component/storybook/stories.rb
+++ b/lib/view_component/storybook/stories.rb
@@ -12,6 +12,10 @@ module ViewComponent
       validate :valid_story_configs
 
       class << self
+        def stories_title(title = nil)
+          self.title = title unless title.nil?
+        end
+
         def story(name, component = default_component, &block)
           story_config = StoryConfig.configure(story_id(name), name, component, layout, &block)
           story_configs << story_config

--- a/spec/dummy/app/components/demo/heading_component.html.erb
+++ b/spec/dummy/app/components/demo/heading_component.html.erb
@@ -1,0 +1,1 @@
+<h1><%= heading_text %></h1>

--- a/spec/dummy/app/components/demo/heading_component.rb
+++ b/spec/dummy/app/components/demo/heading_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Demo
+  class HeadingComponent < ViewComponent::Base
+    def initialize(heading_text:)
+      super
+      @heading_text = heading_text
+    end
+
+    private
+
+    attr_reader :heading_text
+  end
+end

--- a/spec/dummy/test/components/stories/demo/heading_component_stories.rb
+++ b/spec/dummy/test/components/stories/demo/heading_component_stories.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Demo
+  class HeadingComponentStories < ViewComponent::Storybook::Stories
+    stories_title 'Heading Component'
+
+    story :default do
+      controls do
+        heading_text "Heading"
+      end
+    end
+  end
+end

--- a/spec/support/controls_examples.rb
+++ b/spec/support/controls_examples.rb
@@ -12,7 +12,7 @@ shared_examples "a controls config" do
   end
 
   describe "#name" do
-    it "by default is dereived from the param" do
+    it "by default is derived from the param" do
       expect(subject.name).to eq("Button Text")
     end
 

--- a/spec/view_component/storybook/stories_spec.rb
+++ b/spec/view_component/storybook/stories_spec.rb
@@ -145,6 +145,26 @@ RSpec.describe ViewComponent::Storybook::Stories do
       )
     end
 
+    it "converts Stories with customer Stories title" do
+      expect(Demo::HeadingComponentStories.to_csf_params).to eq(
+        title: "Heading Component",
+        stories: [
+          {
+            name: :default,
+            parameters: {
+              server: { id: "demo/heading_component/default" }
+            },
+            args: {
+              heading_text: "Heading"
+            },
+            argTypes: {
+              heading_text: { control: { type: :text }, name: "Heading Text" }
+            }
+          }
+        ]
+      )
+    end
+
     it "converts Stories with parameters" do
       expect(ParametersStories.to_csf_params).to eq(
         title: "Parameters",
@@ -236,6 +256,7 @@ RSpec.describe ViewComponent::Storybook::Stories do
       expect(described_class.all).to eq [
         ContentComponentStories,
         Demo::ButtonComponentStories,
+        Demo::HeadingComponentStories,
         Invalid::DuplicateControlsStories,
         Invalid::DuplicateStoryStories,
         KitchenSinkComponentStories,

--- a/spec/view_component/storybook/stories_spec.rb
+++ b/spec/view_component/storybook/stories_spec.rb
@@ -213,11 +213,11 @@ RSpec.describe ViewComponent::Storybook::Stories do
       )
     end
 
-    it "raises an excpetion if stories are invalid" do
+    it "raises an exception if stories are invalid" do
       expect { Invalid::DuplicateStoryStories.to_csf_params }.to raise_exception(ActiveModel::ValidationError)
     end
 
-    it "raises an excpetion if a story_config is invalid" do
+    it "raises an exception if a story_config is invalid" do
       expect { Invalid::DuplicateControlsStories.to_csf_params }.to raise_exception(ActiveModel::ValidationError)
     end
   end


### PR DESCRIPTION
**Background**
We're implementing our components inside an engine and automatically inferring the Stories title from the component class path is starting to make things a bit unwieldy as the number of components grow. 

This PR allows you to override the title of Stories to whatever you wish so you can better manage the grouping/listing of components in Storybook.