### PR TITLE
Add support for Arrays of Objects

### DIFF
--- a/lib/view_component/storybook/controls/object_config.rb
+++ b/lib/view_component/storybook/controls/object_config.rb
@@ -10,7 +10,12 @@ module ViewComponent
 
         def value_from_param(param)
           if param.is_a?(String)
-            JSON.parse(param).deep_symbolize_keys
+            parsed_json = JSON.parse(param)
+            if parsed_json.is_a?(Array)
+              parsed_json.map(&:deep_symbolize_keys)
+            else
+              parsed_json.deep_symbolize_keys
+            end
           else
             super(param)
           end

--- a/spec/view_component/storybook/controls/object_config_spec.rb
+++ b/spec/view_component/storybook/controls/object_config_spec.rb
@@ -21,4 +21,13 @@ RSpec.describe ViewComponent::Storybook::Controls::ObjectConfig do
       let(:expected_csf_value) { { shape: "square", options: { color: "red", size: 10 } } }
     end
   end
+
+  context "with an array of objects" do
+    it_behaves_like "a controls config" do
+      let(:value) { [{ shape: 'square', color: 'red' }, { shape: 'circle', color: 'green' }] }
+      let(:param_value) { '[{"shape": "square", "color": "red"},{"shape": "circle", "color": "green"}]' }
+
+      let(:expected_csf_value) { [{ shape: 'square', color: 'red' }, { shape: 'circle', color: 'green' }] }
+    end
+  end
 end


### PR DESCRIPTION
Hello 👋 I was trying to create stories where a component would take an array of objects as input (e.g. a Menu Component). Inspired by this original issue on the Storybook repo https://github.com/storybookjs/storybook/issues/810, I've tried to replicate the same behaviour in supporting Arrays of Objects as first class citizens.

cc @elia , @nerfologist