### PR TITLE
Add ValidationErrors, better error messages and stronger exception handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,6 @@ RSpec/MultipleMemoizedHelpers:
 
 Rails/RakeEnvironment:
   Enabled: false
+
+Style/FormatStringToken:
+  Enabled: false

--- a/lib/view_component/storybook/controls/control_config.rb
+++ b/lib/view_component/storybook/controls/control_config.rb
@@ -9,7 +9,14 @@ module ViewComponent
         attr_reader :component, :param, :value, :name
 
         validates :component, :param, presence: true
-        validates :param, inclusion: { in: ->(control_config) { control_config.component_param_names } }, if: :should_validate_params?
+        validates(
+          :param,
+          inclusion: {
+            in: ->(control_config) { control_config.component_param_names },
+            message: "'%{value}' is not supported by the component"
+          },
+          if: :should_validate_params?
+        )
 
         def initialize(component, param, value, name: nil)
           @component = component

--- a/lib/view_component/storybook/tasks/write_stories_json.rake
+++ b/lib/view_component/storybook/tasks/write_stories_json.rake
@@ -4,10 +4,16 @@ namespace :view_component_storybook do
   desc "Write CSF JSON stories for all Stories"
   task write_stories_json: :environment do
     puts "Writing Stories JSON"
+    exceptions = []
     ViewComponent::Storybook::Stories.all.each do |stories|
       json_path = stories.write_csf_json
       puts "#{stories.name} => #{json_path}"
+    rescue StandardError => e
+      exceptions << e
     end
+
+    raise StandardError, exceptions.map(:message).join(", ") if exceptions.present?
+
     puts "Done"
   end
 end

--- a/spec/support/controls_exmples.rb
+++ b/spec/support/controls_exmples.rb
@@ -44,7 +44,7 @@ shared_examples "a controls config" do
       it "is invalid" do
         expect(subject.valid?).to eq(false)
         expect(subject.errors.size).to eq(1)
-        expect(subject.errors[:param]).to eq(["is not included in the list"])
+        expect(subject.errors[:param]).to eq(["'foo' is not supported by the component"])
       end
     end
 

--- a/spec/view_component/storybook/stories_spec.rb
+++ b/spec/view_component/storybook/stories_spec.rb
@@ -200,11 +200,21 @@ RSpec.describe ViewComponent::Storybook::Stories do
     end
 
     it "raises an excpetion if stories are invalid" do
-      expect { Invalid::DuplicateStoryStories.to_csf_params }.to raise_exception(ActiveModel::ValidationError)
+      expect { Invalid::DuplicateStoryStories.to_csf_params }.to(
+        raise_exception(
+          ViewComponent::Storybook::Stories::ValidationError,
+          "Invalid::DuplicateStoryStories invalid: Story configs duplicate story name my_story"
+        )
+      )
     end
 
     it "raises an excpetion if a story_config is invalid" do
-      expect { Invalid::DuplicateControlsStories.to_csf_params }.to raise_exception(ActiveModel::ValidationError)
+      expect { Invalid::DuplicateControlsStories.to_csf_params }.to(
+        raise_exception(
+          ViewComponent::Storybook::Stories::ValidationError,
+          "Invalid::DuplicateControlsStories invalid: Story configs is invalid, Story 'duplicate_controls' invalid: Controls duplicate control name Title"
+        )
+      )
     end
   end
 

--- a/spec/view_component/storybook/story_config_spec.rb
+++ b/spec/view_component/storybook/story_config_spec.rb
@@ -116,7 +116,12 @@ RSpec.describe ViewComponent::Storybook::StoryConfig do
       end
 
       it "raises an excpetion" do
-        expect { subject.to_csf_params }.to raise_exception(ActiveModel::ValidationError)
+        expect { subject.to_csf_params }.to(
+          raise_exception(
+            ViewComponent::Storybook::StoryConfig::ValidationError,
+            "'Example Story Config' invalid: Controls is invalid, Control 'Junk' invalid: Param 'junk' is not supported by the component."
+          )
+        )
       end
     end
   end


### PR DESCRIPTION
Should address the concerns raised in #45

A few new things:
* New ValidationError classes
* Much more verbose error messages
* when writing csf json we write all files, rescuing exceptions and then throw one exception containing all the problems.
  This should help developers as we'll a) write all the files we can b) not stop on the first error c) tell you all the things that fail

cc @strika and @hjhart