### PR TITLE
Add Custom Control

### DIFF
--- a/lib/view_component/storybook/controls.rb
+++ b/lib/view_component/storybook/controls.rb
@@ -17,6 +17,7 @@ module ViewComponent
       autoload :ArrayConfig
       autoload :DateConfig
       autoload :ObjectConfig
+      autoload :CustomConfig
     end
   end
 end

--- a/lib/view_component/storybook/controls/custom_config.rb
+++ b/lib/view_component/storybook/controls/custom_config.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module Storybook
+    module Controls
+      class CustomConfig < ControlConfig
+        attr_reader :value_method_args
+
+        # TODO: Add to Errors with custom messages
+        validate { value_method_args.valid? }
+
+        def with_value(*args, **kwargs, &block)
+          @value_method_args = ViewComponent::Storybook::MethodArgs::ControlMethodArgs.new(block, *args, **kwargs, &block)
+          @value_method_args.with_param_prefix(param)
+          self
+        end
+
+        def param(new_param = nil)
+          value_method_args.with_param_prefix(new_param) unless new_param.nil?
+          super(new_param)
+        end
+
+        def to_csf_params
+          validate!
+          # TODO: Figure out if we can use 'category' with the args table
+          # export default {
+          #   argTypes: {
+          #     foo: {
+          #       table: { category: 'cat', subcategory: 'sub' }
+          #     }
+          #   }
+          # }
+          value_method_args.controls.reduce({}) do |csf_params, control|
+            csf_params.deep_merge(control.to_csf_params)
+          end
+        end
+
+        def value_from_params(params)
+          method_args = value_method_args.resolve_method_args(params)
+
+          method_args.block.call(*method_args.args, **method_args.kwargs)
+        end
+      end
+    end
+  end
+end

--- a/lib/view_component/storybook/dsl/controls_dsl.rb
+++ b/lib/view_component/storybook/dsl/controls_dsl.rb
@@ -60,6 +60,10 @@ module ViewComponent
           Controls::DateConfig.new(default_value)
         end
 
+        def custom(*args, **kwargs, &block)
+          Controls::CustomConfig.new.with_value(*args, **kwargs, &block)
+        end
+
         Controls = ViewComponent::Storybook::Controls
       end
     end

--- a/spec/dummy/test/components/stories/custom_control_stories.rb
+++ b/spec/dummy/test/components/stories/custom_control_stories.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class CustomControlStories < ViewComponent::Storybook::Stories
+  story :custom_text, Demo::ButtonComponent do
+    custom_control = custom(greeting: text("Hi"), name: text("Sarah")) do |greeting:, name:|
+      "#{greeting} #{name}"
+    end
+    constructor(
+      button_text: custom_control
+    )
+  end
+
+  story :custom_rest_args, ArgsComponent do
+    custom_control_one = custom(verb: text("Big"), noun: text("Car")) do |verb:, noun:|
+      "#{verb} #{noun}"
+    end
+    custom_control_two = custom(verb: text("Small"), noun: text("Boat")) do |verb:, noun:|
+      "#{verb} #{noun}"
+    end
+    constructor(
+      custom_control_one,
+      custom_control_two
+    )
+  end
+
+  story :nested_custom_controls, Demo::ButtonComponent do
+    name_control = custom(first_name: text("Sarah"), last_name: text("Connor")) do |first_name:, last_name:|
+      "#{first_name} #{last_name}"
+    end
+    custom_control = custom(greeting: text("Hi"), name: name_control) do |greeting:, name:|
+      "#{greeting} #{name}"
+    end
+    constructor(
+      button_text: custom_control
+    )
+  end
+end

--- a/spec/view_component/storybook/stories_controller_spec.rb
+++ b/spec/view_component/storybook/stories_controller_spec.rb
@@ -113,6 +113,25 @@ RSpec.describe ViewComponent::Storybook::StoriesController, type: :request do
     expect(response.body).to include("<button>My Button</button>")
   end
 
+  it "renders a compoent with custom controls" do
+    get "/rails/stories/custom_control/custom_text", params: { button_text__greeting: "Hello", button_text__name: "Nemo" }
+
+    expect(response.body).to include("<button>Hello Nemo</button>")
+  end
+
+  it "renders a compoent with custom controls for rest args" do
+    get "/rails/stories/custom_control/custom_rest_args",
+        params: {
+          items0__verb: "Heavy",
+          items0__noun: "Rock",
+          items1__verb: "Light",
+          items1__noun: "Feather",
+        }
+
+    expect(response.body).to include("<p>Heavy Rock</p>")
+    expect(response.body).to include("<p>Light Feather</p>")
+  end
+
   it "ignores query params that don't match the the compoents args" do
     get "/rails/stories/demo/button_component/short_button", params: { button_text: "My Button", junk: true }
 

--- a/spec/view_component/storybook/stories_spec.rb
+++ b/spec/view_component/storybook/stories_spec.rb
@@ -327,6 +327,62 @@ RSpec.describe ViewComponent::Storybook::Stories do
       )
     end
 
+    it "converts Stories with custom controls" do
+      expect(CustomControlStories.to_csf_params).to eq(
+        title: "Custom Control",
+        stories: [
+          {
+            name: :custom_text,
+            parameters: {
+              server: { id: "custom_control/custom_text" }
+            },
+            args: {
+              button_text__greeting: "Hi",
+              button_text__name: "Sarah"
+            },
+            argTypes: {
+              button_text__greeting: { control: { type: :text }, name: "Button Text  Greeting" },
+              button_text__name: { control: { type: :text }, name: "Button Text  Name" }
+            }
+          },
+          {
+            name: :custom_rest_args,
+            parameters: {
+              server: { id: "custom_control/custom_rest_args" }
+            },
+            args: {
+              items0__verb: "Big",
+              items0__noun: "Car",
+              items1__verb: "Small",
+              items1__noun: "Boat",
+            },
+            argTypes: {
+              items0__verb: { control: { type: :text }, name: "Items0  Verb" },
+              items0__noun: { control: { type: :text }, name: "Items0  Noun" },
+              items1__verb: { control: { type: :text }, name: "Items1  Verb" },
+              items1__noun: { control: { type: :text }, name: "Items1  Noun" }
+            }
+          },
+          {
+            name: :nested_custom_controls,
+            parameters: {
+              server: { id: "custom_control/nested_custom_controls" }
+            },
+            args: {
+              button_text__greeting: "Hi",
+              button_text__name__first_name: "Sarah",
+              button_text__name__last_name: "Connor"
+            },
+            argTypes: {
+              button_text__greeting: { control: { type: :text }, name: "Button Text  Greeting" },
+              button_text__name__first_name: { control: { type: :text }, name: "Button Text  Name  First Name" },
+              button_text__name__last_name: { control: { type: :text }, name: "Button Text  Name  Last Name" }
+            }
+          }
+        ]
+      )
+    end
+
     it "raises an excpetion if stories are invalid" do
       expect { Invalid::DuplicateStoryStories.to_csf_params }.to(
         raise_exception(
@@ -396,6 +452,7 @@ RSpec.describe ViewComponent::Storybook::Stories do
       expect(described_class.all).to eq [
         ArgsComponentStories,
         ContentComponentStories,
+        CustomControlStories,
         Demo::ButtonComponentStories,
         Invalid::DuplicateStoryStories,
         Invalid::InvalidConstrutorStories,


### PR DESCRIPTION
New API for custom controls that supply their own value

```ruby
 story :custom_text, Demo::ButtonComponent do
    custom_control = custom(greeting: text("Hi"), name: text("Sarah")) do |greeting:, name:|
      "#{greeting} #{name}"
    end
    constructor(
      button_text: custom_control
    )
  end
  ```
  
  We can even nest custom controls:
  
  ```ruby
    story :nested_custom_controls, Demo::ButtonComponent do
    name_control = custom(first_name: text("Sarah"), last_name: text("Connor")) do |first_name:, last_name:|
      "#{first_name} #{last_name}"
    end
    custom_control = custom(greeting: text("Hi"), name: name_control) do |greeting:, name:|
      "#{greeting} #{name}"
    end
    constructor(
      button_text: custom_control
    )
  end
  ```