### PR TITLE
Simpler controls dsl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   lint:

--- a/lib/view_component/storybook/controls.rb
+++ b/lib/view_component/storybook/controls.rb
@@ -8,6 +8,7 @@ module ViewComponent
       extend ActiveSupport::Autoload
 
       autoload :ControlConfig
+      autoload :SimpleControlConfig
       autoload :TextConfig
       autoload :BooleanConfig
       autoload :ColorConfig

--- a/lib/view_component/storybook/controls/array_config.rb
+++ b/lib/view_component/storybook/controls/array_config.rb
@@ -3,13 +3,13 @@
 module ViewComponent
   module Storybook
     module Controls
-      class ArrayConfig < ControlConfig
+      class ArrayConfig < SimpleControlConfig
         attr_reader :separator
 
         validates :separator, presence: true
 
-        def initialize(value, separator = ",", param: nil, name: nil)
-          super(value, param: param, name: name)
+        def initialize(default_value, separator = ",", param: nil, name: nil)
+          super(default_value, param: param, name: name)
           @separator = separator
         end
 

--- a/lib/view_component/storybook/controls/boolean_config.rb
+++ b/lib/view_component/storybook/controls/boolean_config.rb
@@ -3,10 +3,10 @@
 module ViewComponent
   module Storybook
     module Controls
-      class BooleanConfig < ControlConfig
+      class BooleanConfig < SimpleControlConfig
         BOOLEAN_VALUES = [true, false].freeze
 
-        validates :value, inclusion: { in: BOOLEAN_VALUES }, unless: -> { value.nil? }
+        validates :default_value, inclusion: { in: BOOLEAN_VALUES }, unless: -> { default_value.nil? }
 
         def type
           :boolean

--- a/lib/view_component/storybook/controls/color_config.rb
+++ b/lib/view_component/storybook/controls/color_config.rb
@@ -3,11 +3,11 @@
 module ViewComponent
   module Storybook
     module Controls
-      class ColorConfig < ControlConfig
+      class ColorConfig < SimpleControlConfig
         attr_reader :preset_colors
 
-        def initialize(value, param: nil, name: nil, preset_colors: nil)
-          super(value, param: param, name: name)
+        def initialize(default_value, preset_colors: nil, param: nil, name: nil)
+          super(default_value, param: param, name: name)
           @preset_colors = preset_colors
         end
 
@@ -18,8 +18,7 @@ module ViewComponent
         private
 
         def csf_control_params
-          params = super
-          params.merge(presetColors: preset_colors).compact
+          super.merge(presetColors: preset_colors).compact
         end
       end
     end

--- a/lib/view_component/storybook/controls/control_config.rb
+++ b/lib/view_component/storybook/controls/control_config.rb
@@ -6,67 +6,40 @@ module ViewComponent
       class ControlConfig
         include ActiveModel::Validations
 
-        attr_reader :value
-        attr_accessor :param
-
         validates :param, presence: true
-        # validates(
-        #   :param,
-        #   inclusion: {
-        #     in: ->(control_config) { control_config.component_param_names },
-        #     message: "'%{value}' is not supported by the component"
-        #   },
-        #   if: :should_validate_params?
-        # )
 
-        def initialize(value, param: nil, name: nil)
+        def initialize(param: nil, name: nil)
           @param = param
-          @value = value
           @name = name
         end
 
-        def name
-          @name ||= param.to_s.humanize.titlecase
+        def name(new_name = nil)
+          if new_name.nil?
+            @name ||= param.to_s.humanize.titlecase
+          else
+            @name = new_name
+            self
+          end
+        end
+
+        def param(new_param = nil)
+          return @param if new_param.nil?
+
+          @param = new_param
+          self
         end
 
         def to_csf_params
-          validate!
-          {
-            args: { param => csf_value },
-            argTypes: { param => { control: csf_control_params, name: name } }
-          }
+          # :nocov:
+          raise NotImplementedError
+          # :nocov:
         end
 
         def value_from_params(params)
-          params[param]
+          # :nocov:
+          raise NotImplementedError
+          # :nocov:
         end
-
-        # def component_param_names
-        #   @component_param_names ||= component_params&.map(&:last)
-        # end
-
-        private
-
-        # provide extension points for subclasses to vary the value
-        def csf_value
-          value
-        end
-
-        def csf_control_params
-          { type: type }
-        end
-
-        # def component_accepts_kwargs?
-        #   component_params.map(&:first).include?(:keyrest)
-        # end
-
-        # def component_params
-        #   @component_params ||= component.instance_method(:initialize).parameters
-        # end
-
-        # def should_validate_params?
-        #   component.present? && !component_accepts_kwargs?
-        # end
       end
     end
   end

--- a/lib/view_component/storybook/controls/date_config.rb
+++ b/lib/view_component/storybook/controls/date_config.rb
@@ -3,9 +3,9 @@
 module ViewComponent
   module Storybook
     module Controls
-      class DateConfig < ControlConfig
-        def initialize(value, param: nil, name: nil)
-          super(value, param: param, name: name)
+      class DateConfig < SimpleControlConfig
+        def initialize(default_value, param: nil, name: nil)
+          super(default_value, param: param, name: name)
         end
 
         def type
@@ -24,10 +24,12 @@ module ViewComponent
         private
 
         def csf_value
-          params_value = value
-          params_value = params_value.in_time_zone if params_value.is_a?(Date)
-          params_value = params_value.iso8601 if params_value.is_a?(Time)
-          params_value
+          case default_value
+          when Date
+            default_value.in_time_zone
+          when Time
+            default_value.iso8601
+          end
         end
       end
     end

--- a/lib/view_component/storybook/controls/number_config.rb
+++ b/lib/view_component/storybook/controls/number_config.rb
@@ -3,7 +3,7 @@
 module ViewComponent
   module Storybook
     module Controls
-      class NumberConfig < ControlConfig
+      class NumberConfig < SimpleControlConfig
         TYPES = %i[number range].freeze
 
         attr_reader :type, :min, :max, :step
@@ -11,8 +11,8 @@ module ViewComponent
         validates :type, presence: true
         validates :type, inclusion: { in: TYPES }, unless: -> { type.nil? }
 
-        def initialize(type, value, min: nil, max: nil, step: nil, param: nil, name: nil)
-          super(value, param: param, name: name)
+        def initialize(type, default_value, min: nil, max: nil, step: nil, param: nil, name: nil)
+          super(default_value, param: param, name: name)
           @type = type
           @min = min
           @max = max
@@ -31,8 +31,7 @@ module ViewComponent
         private
 
         def csf_control_params
-          params = super
-          params.merge(min: min, max: max, step: step).compact
+          super.merge(min: min, max: max, step: step).compact
         end
       end
     end

--- a/lib/view_component/storybook/controls/object_config.rb
+++ b/lib/view_component/storybook/controls/object_config.rb
@@ -3,7 +3,7 @@
 module ViewComponent
   module Storybook
     module Controls
-      class ObjectConfig < ControlConfig
+      class ObjectConfig < SimpleControlConfig
         def type
           :object
         end

--- a/lib/view_component/storybook/controls/options_config.rb
+++ b/lib/view_component/storybook/controls/options_config.rb
@@ -3,7 +3,7 @@
 module ViewComponent
   module Storybook
     module Controls
-      class OptionsConfig < ControlConfig
+      class OptionsConfig < SimpleControlConfig
         class << self
           # support the options being a Hash or an Array. Storybook supports either.
           def inclusion_in(config)
@@ -22,7 +22,7 @@ module ViewComponent
 
         validates :type, :options, presence: true
         validates :type, inclusion: { in: TYPES }, unless: -> { type.nil? }
-        validates :value, inclusion: { in: method(:inclusion_in) }, unless: -> { options.nil? || value.nil? }
+        validates :default_value, inclusion: { in: method(:inclusion_in) }, unless: -> { options.nil? || default_value.nil? }
 
         def initialize(type, options, default_value, param: nil, name: nil)
           super(default_value, param: param, name: name)

--- a/lib/view_component/storybook/controls/simple_control_config.rb
+++ b/lib/view_component/storybook/controls/simple_control_config.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module Storybook
+    module Controls
+      ##
+      # A simple Control Config maps to one Storybook Control
+      # It has a value and pulls its value from params by key
+      class SimpleControlConfig < ControlConfig
+        attr_reader :default_value
+
+        def initialize(default_value, param: nil, name: nil)
+          super(param: param, name: name)
+          @default_value = default_value
+        end
+
+        def to_csf_params
+          validate!
+          {
+            args: { param => csf_value },
+            argTypes: { param => { control: csf_control_params, name: name } }
+          }
+        end
+
+        def value_from_params(params)
+          params[param]
+        end
+
+        private
+
+        # provide extension points for subclasses to vary the value
+        def type
+          # :nocov:
+          raise NotImplementedError
+          # :nocov:
+        end
+
+        def csf_value
+          default_value
+        end
+
+        def csf_control_params
+          { type: type }
+        end
+      end
+    end
+  end
+end

--- a/lib/view_component/storybook/controls/text_config.rb
+++ b/lib/view_component/storybook/controls/text_config.rb
@@ -3,7 +3,7 @@
 module ViewComponent
   module Storybook
     module Controls
-      class TextConfig < ControlConfig
+      class TextConfig < SimpleControlConfig
         def type
           :text
         end

--- a/lib/view_component/storybook/dsl/controls_dsl.rb
+++ b/lib/view_component/storybook/dsl/controls_dsl.rb
@@ -4,60 +4,60 @@ module ViewComponent
   module Storybook
     module Dsl
       module ControlsDsl
-        def text(value, param: nil, name: nil)
-          Controls::TextConfig.new(value, param: param, name: name)
+        def text(default_value)
+          Controls::TextConfig.new(default_value)
         end
 
-        def boolean(value, param: nil, name: nil)
-          Controls::BooleanConfig.new(value, param: param, name: name)
+        def boolean(default_value)
+          Controls::BooleanConfig.new(default_value)
         end
 
-        def number(value, param: nil, name: nil, min: nil, max: nil, step: nil)
-          Controls::NumberConfig.new(:number, value, param: param, name: name, min: min, max: max, step: step)
+        def number(default_value, min: nil, max: nil, step: nil)
+          Controls::NumberConfig.new(:number, default_value, min: min, max: max, step: step)
         end
 
-        def range(value, param: nil, name: nil, min: nil, max: nil, step: nil)
-          Controls::NumberConfig.new(:range, value, param: param, name: name, min: min, max: max, step: step)
+        def range(default_value, min: nil, max: nil, step: nil)
+          Controls::NumberConfig.new(:range, default_value, min: min, max: max, step: step)
         end
 
-        def color(value, param: nil, name: nil, preset_colors: nil)
-          Controls::ColorConfig.new(value, param: param, name: name, preset_colors: preset_colors)
+        def color(default_value, preset_colors: nil)
+          Controls::ColorConfig.new(default_value, preset_colors: preset_colors)
         end
 
-        def object(value, param: nil, name: nil)
-          Controls::ObjectConfig.new(value, param: param, name: name)
+        def object(default_value)
+          Controls::ObjectConfig.new(default_value)
         end
 
-        def select(options, value, param: nil, name: nil)
-          Controls::OptionsConfig.new(:select, options, value, param: param, name: name)
+        def select(options, default_value)
+          Controls::OptionsConfig.new(:select, options, default_value)
         end
 
-        def multi_select(options, value, param: nil, name: nil)
-          Controls::OptionsConfig.new(:'multi-select', options, value, param: param, name: name)
+        def multi_select(options, default_value)
+          Controls::OptionsConfig.new(:'multi-select', options, default_value)
         end
 
-        def radio(options, value, param: nil, name: nil)
-          Controls::OptionsConfig.new(:radio, options, value, param: param, name: name)
+        def radio(options, default_value)
+          Controls::OptionsConfig.new(:radio, options, default_value)
         end
 
-        def inline_radio(options, value, param: nil, name: nil)
-          Controls::OptionsConfig.new(:'inline-radio', options, value, param: param, name: name)
+        def inline_radio(options, default_value)
+          Controls::OptionsConfig.new(:'inline-radio', options, default_value)
         end
 
-        def check(options, value, param: nil, name: nil)
-          Controls::OptionsConfig.new(:check, options, value, param: param, name: name)
+        def check(options, default_value)
+          Controls::OptionsConfig.new(:check, options, default_value)
         end
 
-        def inline_check(options, value, param: nil, name: nil)
-          Controls::OptionsConfig.new(:'inline-check', options, value, param: param, name: name)
+        def inline_check(options, default_value)
+          Controls::OptionsConfig.new(:'inline-check', options, default_value)
         end
 
-        def array(value, separator = ",", param: nil, name: nil)
-          Controls::ArrayConfig.new(value, separator, param: param, name: name)
+        def array(default_value, separator = ",")
+          Controls::ArrayConfig.new(default_value, separator)
         end
 
-        def date(value, param: nil, name: nil)
-          Controls::DateConfig.new(value, param: param, name: name)
+        def date(default_value)
+          Controls::DateConfig.new(default_value)
         end
 
         Controls = ViewComponent::Storybook::Controls

--- a/lib/view_component/storybook/method_args/control_method_args.rb
+++ b/lib/view_component/storybook/method_args/control_method_args.rb
@@ -50,18 +50,18 @@ module ViewComponent
 
         def assign_control_params
           args.each_with_index do |arg, index|
-            arg.param = target_method_params_names.arg_name(index) if control?(arg) && arg.param.nil?
+            arg.param(target_method_params_names.arg_name(index)) if control?(arg) && arg.param.nil?
           end
 
           kwargs.each do |key, arg|
-            arg.param = key if control?(arg) && arg.param.nil?
+            arg.param(key) if control?(arg) && arg.param.nil?
           end
         end
 
         def value_from_params(arg, params)
           if control?(arg)
             value = arg.value_from_params(params)
-            value = arg.value if value.nil? # nil only not falsey
+            value = arg.default_value if value.nil? # nil only not falsey
             value
           else
             arg

--- a/spec/dummy/test/components/stories/args_component_stories.rb
+++ b/spec/dummy/test/components/stories/args_component_stories.rb
@@ -17,7 +17,7 @@ class ArgsComponentStories < ViewComponent::Storybook::Stories
 
   story :custom_param do
     constructor(
-      text("Hello World!", param: :message),
+      text("Hello World!").param(:message),
       text("How you doing?")
     )
   end

--- a/spec/dummy/test/components/stories/kwargs_component_stories.rb
+++ b/spec/dummy/test/components/stories/kwargs_component_stories.rb
@@ -19,7 +19,7 @@ class KwargsComponentStories < ViewComponent::Storybook::Stories
 
   story :custom_param do
     constructor(
-      message: text("Hello World!", param: :my_message),
+      message: text("Hello World!").param(:my_message),
       param: number(1)
     )
   end

--- a/spec/support/controls_exmples.rb
+++ b/spec/support/controls_exmples.rb
@@ -2,12 +2,24 @@
 
 shared_examples "a controls config" do
   let(:param) { :button_text }
-  let(:value) { "OK" }
+  let(:default_value) { "OK" }
+  let(:value_from_param) { "OK" }
   let(:name) { nil }
-  let(:group_id) { nil }
 
   it "#type" do
     expect(subject.type).to eq(type)
+  end
+
+  describe "#param" do
+    it "can be set" do
+      subject.param(:name)
+
+      expect(subject.param).to eq(:name)
+    end
+
+    it "set returns the control" do
+      expect(subject.param(:name)).to eq(subject)
+    end
   end
 
   describe "#name" do
@@ -22,6 +34,16 @@ shared_examples "a controls config" do
         expect(subject.name).to eq("Button")
       end
     end
+
+    it "can be set" do
+      subject.name("Button")
+
+      expect(subject.name).to eq("Button")
+    end
+
+    it "set returns the control" do
+      expect(subject.name("Button")).to eq(subject)
+    end
   end
 
   describe "#valid?" do
@@ -29,8 +51,8 @@ shared_examples "a controls config" do
       expect(subject.valid?).to eq(true)
     end
 
-    context "without a value" do
-      let(:value) { nil }
+    context "without a default_value" do
+      let(:default_value) { nil }
 
       it "is valid" do
         expect(subject.valid?).to eq(true)
@@ -48,7 +70,7 @@ shared_examples "a controls config" do
     end
   end
 
-  let(:expected_csf_value) { value }
+  let(:expected_csf_value) { default_value }
   let(:csf_arg_type_control_overrides) { {} }
   let(:expected_csf_params) do
     {
@@ -86,7 +108,7 @@ shared_examples "a controls config" do
   let(:param_value) { "OK" }
   describe "#value_from_param" do
     it "parses param_value" do
-      expect(subject.value_from_params(subject.param => param_value)).to eq(value)
+      expect(subject.value_from_params(subject.param => param_value)).to eq(default_value)
     end
 
     it "parses nil param_value" do

--- a/spec/view_component/storybook/controls/array_config_spec.rb
+++ b/spec/view_component/storybook/controls/array_config_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe ViewComponent::Storybook::Controls::ArrayConfig do
-  subject { described_class.new(value, separator, param: param, name: name) }
+  subject { described_class.new(default_value, separator, param: param, name: name) }
 
   let(:separator) { "," }
 
   it_behaves_like "a controls config" do
     let(:type) { :array }
-    let(:value) { %w[red orange yellow] }
+    let(:default_value) { %w[red orange yellow] }
     let(:param_value) { "red,orange,yellow" }
 
     let(:expect_csf_value) { %w[red orange yellow] }

--- a/spec/view_component/storybook/controls/boolean_config_spec.rb
+++ b/spec/view_component/storybook/controls/boolean_config_spec.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe ViewComponent::Storybook::Controls::BooleanConfig do
-  subject { described_class.new(value, param: param, name: name) }
+  subject { described_class.new(default_value, param: param, name: name) }
 
   let(:type) { :boolean }
 
   context "with 'true' value" do
     it_behaves_like "a controls config" do
-      let(:value) { true }
+      let(:default_value) { true }
       let(:param_value) { "true" }
     end
   end
 
   context "with 'false' value" do
     it_behaves_like "a controls config" do
-      let(:value) { false }
+      let(:default_value) { false }
       let(:param_value) { "false" }
     end
   end

--- a/spec/view_component/storybook/controls/color_config_spec.rb
+++ b/spec/view_component/storybook/controls/color_config_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe ViewComponent::Storybook::Controls::ColorConfig do
-  subject { described_class.new(value, param: param, name: name) }
+  subject { described_class.new(default_value, param: param, name: name) }
 
   let(:type) { :color }
 
   it_behaves_like "a controls config"
 
   context "with :preset_color array" do
-    subject { described_class.new(value, param: param, name: name, preset_colors: preset_colors) }
+    subject { described_class.new(default_value, param: param, name: name, preset_colors: preset_colors) }
 
     let(:preset_colors) { %w[red green blue] }
 

--- a/spec/view_component/storybook/controls/date_config_spec.rb
+++ b/spec/view_component/storybook/controls/date_config_spec.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe ViewComponent::Storybook::Controls::DateConfig do
-  subject { described_class.new(value, param: param, name: name) }
+  subject { described_class.new(default_value, param: param, name: name) }
 
   shared_examples "valid with object value" do
     it "has a value" do
-      expect(subject.value).to eq(value)
+      expect(subject.default_value).to eq(default_value)
     end
 
     it "to_csf_params should leave value alone" do
       subject.to_csf_params
-      expect(subject.value).to eq(value)
+      expect(subject.default_value).to eq(default_value)
     end
 
     it "is valid" do
@@ -35,7 +35,7 @@ RSpec.describe ViewComponent::Storybook::Controls::DateConfig do
 
   context "with Date value" do
     it_behaves_like "a controls config" do
-      let(:value) { Date.new(2020, 2, 15) }
+      let(:default_value) { Date.new(2020, 2, 15) }
       let(:param_value) { "2020-02-15T00:00:00Z" }
 
       let(:expected_csf_value) { "2020-02-15T00:00:00Z" }
@@ -46,7 +46,7 @@ RSpec.describe ViewComponent::Storybook::Controls::DateConfig do
 
   context "with DateTime value" do
     it_behaves_like "a controls config" do
-      let(:value) { Time.utc(2020, 2, 15, 2, 30, 45).to_datetime }
+      let(:default_value) { Time.utc(2020, 2, 15, 2, 30, 45).to_datetime }
       let(:param_value) { "2020-02-15T02:30:45Z" }
 
       let(:expected_csf_value) { "2020-02-15T02:30:45Z" }
@@ -57,7 +57,7 @@ RSpec.describe ViewComponent::Storybook::Controls::DateConfig do
 
   context "with Time value" do
     it_behaves_like "a controls config" do
-      let(:value) { Time.utc(2020, 2, 15, 2, 30, 45) }
+      let(:default_value) { Time.utc(2020, 2, 15, 2, 30, 45) }
       let(:param_value) { "2020-02-15T02:30:45Z" }
 
       let(:expected_csf_value) { "2020-02-15T02:30:45Z" }

--- a/spec/view_component/storybook/controls/number_config_spec.rb
+++ b/spec/view_component/storybook/controls/number_config_spec.rb
@@ -3,30 +3,30 @@
 RSpec.describe ViewComponent::Storybook::Controls::NumberConfig do
   described_class::TYPES.each do |number_type|
     context "with '#{number_type}' type" do
-      subject { described_class.new(number_type, value, param: param, name: name) }
+      subject { described_class.new(number_type, default_value, param: param, name: name) }
 
       it_behaves_like "a controls config" do
         let(:type) { number_type }
-        let(:value) { 15 }
+        let(:default_value) { 15 }
         let(:param_value) { "15" }
       end
 
       context "with float value" do
         it_behaves_like "a controls config" do
           let(:type) { number_type }
-          let(:value) { 15.634 }
+          let(:default_value) { 15.634 }
           let(:param_value) { "15.634" }
         end
       end
 
       context "with options" do
-        subject { described_class.new(number_type, value, **number_options, param: param, name: name) }
+        subject { described_class.new(number_type, default_value, **number_options, param: param, name: name) }
 
         let(:number_options) { { min: 60, max: 90, step: 1 } }
 
         it_behaves_like "a controls config" do
           let(:type) { number_type }
-          let(:value) { 15 }
+          let(:default_value) { 15 }
           let(:param_value) { "15" }
 
           let(:csf_arg_type_control_overrides) { number_options }

--- a/spec/view_component/storybook/controls/object_config_spec.rb
+++ b/spec/view_component/storybook/controls/object_config_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe ViewComponent::Storybook::Controls::ObjectConfig do
-  subject { described_class.new(value, param: param, name: name) }
+  subject { described_class.new(default_value, param: param, name: name) }
 
   let(:separator) { "," }
   let(:type) { :object }
 
   it_behaves_like "a controls config" do
-    let(:value) { { color: "red", shape: "square" } }
+    let(:default_value) { { color: "red", shape: "square" } }
     let(:param_value) { '{"color":"red","shape":"square"}' }
 
     let(:expected_csf_value) { { color: "red", shape: "square" } }
@@ -15,7 +15,7 @@ RSpec.describe ViewComponent::Storybook::Controls::ObjectConfig do
 
   context "with nested value" do
     it_behaves_like "a controls config" do
-      let(:value) { { shape: "square", options: { color: "red", size: 10 } } }
+      let(:default_value) { { shape: "square", options: { color: "red", size: 10 } } }
       let(:param_value) { '{"shape":"square","options":{"color":"red", "size":10}}' }
 
       let(:expected_csf_value) { { shape: "square", options: { color: "red", size: 10 } } }
@@ -24,7 +24,7 @@ RSpec.describe ViewComponent::Storybook::Controls::ObjectConfig do
 
   context "with an array of objects" do
     it_behaves_like "a controls config" do
-      let(:value) { [{ shape: 'square', color: 'red' }, { shape: 'circle', color: 'green' }] }
+      let(:default_value) { [{ shape: 'square', color: 'red' }, { shape: 'circle', color: 'green' }] }
       let(:param_value) { '[{"shape": "square", "color": "red"},{"shape": "circle", "color": "green"}]' }
 
       let(:expected_csf_value) { [{ shape: 'square', color: 'red' }, { shape: 'circle', color: 'green' }] }

--- a/spec/view_component/storybook/controls/options_config_spec.rb
+++ b/spec/view_component/storybook/controls/options_config_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
       let(:type) { type }
 
       it_behaves_like "a controls config" do
-        subject { described_class.new(type, options, value, param: param, name: name) }
+        subject { described_class.new(type, options, default_value, param: param, name: name) }
 
-        let(:value) { "blue" }
+        let(:default_value) { "blue" }
         let(:param_value) { "blue" }
 
         let(:csf_arg_type_control_overrides) { { options: options } }
@@ -20,9 +20,9 @@ RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
         let(:options) { { Red: :red, Blue: :blue, Yellow: :yellow } }
 
         it_behaves_like "a controls config" do
-          subject { described_class.new(type, options, value, param: param, name: name) }
+          subject { described_class.new(type, options, default_value, param: param, name: name) }
 
-          let(:value) { :blue }
+          let(:default_value) { :blue }
           let(:param_value) { "blue" }
 
           let(:csf_arg_type_control_overrides) { { options: options } }
@@ -33,9 +33,9 @@ RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
         let(:options) { %w[red blue yellow] }
 
         it_behaves_like "a controls config" do
-          subject { described_class.new(type, options, value, param: param, name: name) }
+          subject { described_class.new(type, options, default_value, param: param, name: name) }
 
-          let(:value) { "blue" }
+          let(:default_value) { "blue" }
           let(:param_value) { "blue" }
 
           let(:csf_arg_type_control_overrides) { { options: options } }
@@ -46,9 +46,9 @@ RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
         let(:options) { %i[red blue yellow] }
 
         it_behaves_like "a controls config" do
-          subject { described_class.new(type, options, value, param: param, name: name) }
+          subject { described_class.new(type, options, default_value, param: param, name: name) }
 
-          let(:value) { :blue }
+          let(:default_value) { :blue }
           let(:param_value) { "blue" }
 
           let(:csf_arg_type_control_overrides) { { options: options } }
@@ -79,7 +79,7 @@ RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
 
       expect(subject.valid?).to eq(false)
       expect(subject.errors.size).to eq(1)
-      expect(subject.errors[:value]).to eq(["is not included in the list"])
+      expect(subject.errors[:default_value]).to eq(["is not included in the list"])
     end
 
     context "with array options" do
@@ -90,7 +90,7 @@ RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
 
         expect(subject.valid?).to eq(false)
         expect(subject.errors.size).to eq(1)
-        expect(subject.errors[:value]).to eq(["is not included in the list"])
+        expect(subject.errors[:default_value]).to eq(["is not included in the list"])
       end
 
       it "valid with nil default_value provided its in the options list" do

--- a/spec/view_component/storybook/controls/text_config_spec.rb
+++ b/spec/view_component/storybook/controls/text_config_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe ViewComponent::Storybook::Controls::TextConfig do
-  subject { described_class.new(value, param: param, name: name) }
+  subject { described_class.new(default_value, param: param, name: name) }
 
   let(:type) { :text }
 

--- a/spec/view_component/storybook/dsl/controls_dsl_spec.rb
+++ b/spec/view_component/storybook/dsl/controls_dsl_spec.rb
@@ -10,32 +10,32 @@ RSpec.describe ViewComponent::Storybook::Dsl::ControlsDsl do
   end
 
   describe "#text" do
-    subject { text("Jame Doe", param: :name) }
+    subject { text("Jame Doe").param(:name) }
 
     include_examples "has controls attributes",
                      {
                        class: ViewComponent::Storybook::Controls::TextConfig,
                        param: :name,
                        name: "Name",
-                       value: "Jame Doe"
+                       default_value: "Jame Doe"
                      }
   end
 
   describe "#boolean" do
-    subject { boolean(true, param: :likes_people) }
+    subject { boolean(true).param(:likes_people) }
 
     include_examples "has controls attributes",
                      {
                        class: ViewComponent::Storybook::Controls::BooleanConfig,
                        param: :likes_people,
                        name: "Likes People",
-                       value: true
+                       default_value: true
                      }
   end
 
   describe "#number" do
     context "with minimal args" do
-      subject { number(2, param: :number_pets) }
+      subject { number(2).param(:number_pets) }
 
       include_examples "has controls attributes",
                        {
@@ -43,7 +43,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::ControlsDsl do
                          type: :number,
                          param: :number_pets,
                          name: "Number Pets",
-                         value: 2,
+                         default_value: 2,
                          min: nil,
                          max: nil,
                          step: nil
@@ -51,7 +51,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::ControlsDsl do
     end
 
     context "with all args" do
-      subject { number(2, min: 0, max: 10, step: 1, param: :number_pets) }
+      subject { number(2, min: 0, max: 10, step: 1).param(:number_pets) }
 
       include_examples "has controls attributes",
                        {
@@ -59,7 +59,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::ControlsDsl do
                          type: :number,
                          param: :number_pets,
                          name: "Number Pets",
-                         value: 2,
+                         default_value: 2,
                          min: 0,
                          max: 10,
                          step: 1
@@ -69,7 +69,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::ControlsDsl do
 
   describe "#range" do
     context "with minimal args" do
-      subject { range(2, param: :number_pets) }
+      subject { range(2).param(:number_pets) }
 
       include_examples "has controls attributes",
                        {
@@ -77,7 +77,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::ControlsDsl do
                          type: :range,
                          param: :number_pets,
                          name: "Number Pets",
-                         value: 2,
+                         default_value: 2,
                          min: nil,
                          max: nil,
                          step: nil
@@ -85,15 +85,15 @@ RSpec.describe ViewComponent::Storybook::Dsl::ControlsDsl do
     end
 
     context "with all args" do
-      subject { range(2, min: 0, max: 10, step: 1, name: "Pets", param: :number_pets) }
+      subject { range(2, min: 0, max: 10, step: 1).param(:number_pets) }
 
       include_examples "has controls attributes",
                        {
                          class: ViewComponent::Storybook::Controls::NumberConfig,
                          type: :range,
                          param: :number_pets,
-                         name: "Pets",
-                         value: 2,
+                         name: "Number Pets",
+                         default_value: 2,
                          min: 0,
                          max: 10,
                          step: 1
@@ -102,26 +102,26 @@ RSpec.describe ViewComponent::Storybook::Dsl::ControlsDsl do
   end
 
   describe "#color" do
-    subject { color("red", param: :favorite_color) }
+    subject { color("red").param(:favorite_color) }
 
     include_examples "has controls attributes",
                      {
                        class: ViewComponent::Storybook::Controls::ColorConfig,
                        param: :favorite_color,
                        name: "Favorite Color",
-                       value: "red"
+                       default_value: "red"
                      }
   end
 
   describe "#object" do
-    subject { object({ hair: "Brown", eyes: "Blue" }, param: :other_things) }
+    subject { object({ hair: "Brown", eyes: "Blue" }).param(:other_things) }
 
     include_examples "has controls attributes",
                      {
                        class: ViewComponent::Storybook::Controls::ObjectConfig,
                        param: :other_things,
                        name: "Other Things",
-                       value: { hair: "Brown", eyes: "Blue" }
+                       default_value: { hair: "Brown", eyes: "Blue" }
                      }
   end
 
@@ -129,7 +129,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::ControlsDsl do
     dsl_method = type.underscore
 
     describe "##{dsl_method}" do
-      subject { send(dsl_method, { hot_dog: "Hot Dog", pizza: "Pizza" }, "Pizza", param: :favorite_food) }
+      subject { send(dsl_method, { hot_dog: "Hot Dog", pizza: "Pizza" }, "Pizza").param(:favorite_food) }
 
       include_examples "has controls attributes",
                        {
@@ -137,7 +137,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::ControlsDsl do
                          type: type.to_sym,
                          param: :favorite_food,
                          name: "Favorite Food",
-                         value: "Pizza",
+                         default_value: "Pizza",
                          options: { hot_dog: "Hot Dog", pizza: "Pizza" }
                        }
     end

--- a/spec/view_component/storybook/dsl/legacy_controls_dsl_spec.rb
+++ b/spec/view_component/storybook/dsl/legacy_controls_dsl_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
         class: ViewComponent::Storybook::Controls::TextConfig,
         param: :name,
         name: "Name",
-        value: "Jame Doe"
+        default_value: "Jame Doe"
       }
     ]
   end
@@ -30,7 +30,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
         class: ViewComponent::Storybook::Controls::BooleanConfig,
         param: :likes_people,
         name: "Likes People",
-        value: true
+        default_value: true
       }
     ]
   end
@@ -45,7 +45,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
           type: :number,
           param: :number_pets,
           name: "Number Pets",
-          value: 2,
+          default_value: 2,
           min: nil,
           max: nil,
           step: nil
@@ -62,7 +62,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
           type: :number,
           param: :number_pets,
           name: "Number Pets",
-          value: 2,
+          default_value: 2,
           min: 0,
           max: 10,
           step: 1
@@ -81,7 +81,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
           type: :range,
           param: :number_pets,
           name: "Number Pets",
-          value: 2,
+          default_value: 2,
           min: nil,
           max: nil,
           step: nil
@@ -98,7 +98,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
           type: :range,
           param: :number_pets,
           name: "Pets",
-          value: 2,
+          default_value: 2,
           min: 0,
           max: 10,
           step: 1
@@ -115,7 +115,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
         class: ViewComponent::Storybook::Controls::ColorConfig,
         param: :favorite_color,
         name: "Favorite Color",
-        value: "red"
+        default_value: "red"
       }
     ]
   end
@@ -128,7 +128,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
         class: ViewComponent::Storybook::Controls::ObjectConfig,
         param: :other_things,
         name: "Other Things",
-        value: { hair: "Brown", eyes: "Blue" }
+        default_value: { hair: "Brown", eyes: "Blue" }
       }
     ]
   end
@@ -145,7 +145,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
           type: type.to_sym,
           param: :favorite_food,
           name: "Favorite Food",
-          value: "Pizza",
+          default_value: "Pizza",
           options: { hot_dog: "Hot Dog", pizza: "Pizza" }
         }
       ]
@@ -161,7 +161,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
           class: ViewComponent::Storybook::Controls::DateConfig,
           param: :birthday,
           name: "Birthday",
-          value: Date.new(1950, 3, 26)
+          default_value: Date.new(1950, 3, 26)
         }
       ]
     end
@@ -174,7 +174,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
           class: ViewComponent::Storybook::Controls::ArrayConfig,
           param: :sports,
           name: "Sports",
-          value: %w[football baseball],
+          default_value: %w[football baseball],
           separator: "|"
         }
       ]
@@ -188,7 +188,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
           class: ViewComponent::Storybook::Controls::ObjectConfig,
           param: :other_things,
           name: "Other Things",
-          value: { hair: "Brown", eyes: "Blue" }
+          default_value: { hair: "Brown", eyes: "Blue" }
         }
       ]
     end
@@ -201,7 +201,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
           class: ViewComponent::Storybook::Controls::NumberConfig,
           param: :number_pets,
           name: "Number Pets",
-          value: 2
+          default_value: 2
         }
       ]
     end
@@ -214,7 +214,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
           class: ViewComponent::Storybook::Controls::NumberConfig,
           param: :number_pets,
           name: "Number Pets",
-          value: 2.5
+          default_value: 2.5
         }
       ]
     end
@@ -227,7 +227,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
           class: ViewComponent::Storybook::Controls::BooleanConfig,
           param: :like_people,
           name: "Like People",
-          value: true
+          default_value: true
         }
       ]
     end
@@ -240,7 +240,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
           class: ViewComponent::Storybook::Controls::BooleanConfig,
           param: :like_people,
           name: "Like People",
-          value: false
+          default_value: false
         }
       ]
     end
@@ -253,7 +253,7 @@ RSpec.describe ViewComponent::Storybook::Dsl::LegacyControlsDsl do
           class: ViewComponent::Storybook::Controls::TextConfig,
           param: :name,
           name: "Name",
-          value: "Jame Doe"
+          default_value: "Jame Doe"
         }
       ]
     end

--- a/spec/view_component/storybook/story_config_spec.rb
+++ b/spec/view_component/storybook/story_config_spec.rb
@@ -298,7 +298,7 @@ RSpec.describe ViewComponent::Storybook::StoryConfig do
         expect { subject.to_csf_params }.to(
           raise_exception(
             ViewComponent::Storybook::StoryConfig::ValidationError,
-            "'Example Story Config' invalid: Constructor args invalid: Controls is invalid, Control 'Title' invalid: Value is not included in the list"
+            "'Example Story Config' invalid: Constructor args invalid: Controls is invalid, Control 'Title' invalid: Default value is not included in the list"
           )
         )
       end


### PR DESCRIPTION
Replace the Controls DSL optional `name` and `param` arguments with a fluid api.
This will allow us to further simplify the custom control dsl in #52 to remove the `with_value`

