### PR TITLE
Support providing content as a string instead of a block

### DIFF
--- a/lib/view_component/storybook/dsl/story_dsl.rb
+++ b/lib/view_component/storybook/dsl/story_dsl.rb
@@ -26,8 +26,8 @@ module ViewComponent
           story_config.layout = layout
         end
 
-        def content(&block)
-          story_config.content_block = block
+        def content(content_str = nil, &block)
+          story_config.content_block = content_str.present? ? proc { content_str } : block
         end
 
         def constructor(*args, **kwargs, &block)

--- a/spec/dummy/test/components/stories/content_component_stories.rb
+++ b/spec/dummy/test/components/stories/content_component_stories.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class ContentComponentStories < ViewComponent::Storybook::Stories
-  story :default do
+  story :with_string_content do
+    content "Hello World!"
+  end
+
+  story :with_block_content do
     content do
       "Hello World!"
     end
@@ -9,7 +13,7 @@ class ContentComponentStories < ViewComponent::Storybook::Stories
 
   story :with_helper_content do
     content do
-      link_to 'Hello World!', '#'
+      link_to "Hello World!", "#"
     end
   end
 

--- a/spec/view_component/storybook/stories_controller_spec.rb
+++ b/spec/view_component/storybook/stories_controller_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe ViewComponent::Storybook::StoriesController, type: :request do
   it "returns ok" do
-    get "/rails/stories/content_component/default"
+    get "/rails/stories/content_component/with_string_content"
 
     expect(response).to have_http_status(:ok)
   end
@@ -157,13 +157,19 @@ RSpec.describe ViewComponent::Storybook::StoriesController, type: :request do
   end
 
   describe "component content" do
-    it "renders the component content" do
-      get "/rails/stories/content_component/default"
+    it "renders the component string content" do
+      get "/rails/stories/content_component/with_string_content"
 
       expect(response.body).to include("<h1>Hello World!</h1>")
     end
 
-    it "renders the component content with helper" do
+    it "renders the component block content" do
+      get "/rails/stories/content_component/with_block_content"
+
+      expect(response.body).to include("<h1>Hello World!</h1>")
+    end
+
+    it "renders the component block content with helper" do
       get "/rails/stories/content_component/with_helper_content"
 
       expect(response.body).to include('<h1><a href="#">Hello World!</a></h1>')

--- a/spec/view_component/storybook/stories_spec.rb
+++ b/spec/view_component/storybook/stories_spec.rb
@@ -19,9 +19,15 @@ RSpec.describe ViewComponent::Storybook::Stories do
         title: "Content Component",
         stories: [
           {
-            name: :default,
+            name: :with_string_content,
             parameters: {
-              server: { id: "content_component/default" }
+              server: { id: "content_component/with_string_content" }
+            }
+          },
+          {
+            name: :with_block_content,
+            parameters: {
+              server: { id: "content_component/with_block_content" }
             }
           },
           {
@@ -417,10 +423,18 @@ RSpec.describe ViewComponent::Storybook::Stories do
             "title": "Content Component",
             "stories": [
               {
-                "name": "default",
+                "name": "with_string_content",
                 "parameters": {
                   "server": {
-                    "id": "content_component/default"
+                    "id": "content_component/with_string_content"
+                  }
+                }
+              },
+              {
+                "name": "with_block_content",
+                "parameters": {
+                  "server": {
+                    "id": "content_component/with_block_content"
                   }
                 }
               },


### PR DESCRIPTION
Mimics the `with_content` behavior of ViewComponents