### PR TITLE
Add CustomControl spec

### DIFF
--- a/spec/support/controls_exmples.rb
+++ b/spec/support/controls_exmples.rb
@@ -2,13 +2,7 @@
 
 shared_examples "a controls config" do
   let(:param) { :button_text }
-  let(:default_value) { "OK" }
-  let(:value_from_param) { "OK" }
   let(:name) { nil }
-
-  it "#type" do
-    expect(subject.type).to eq(type)
-  end
 
   describe "#param" do
     it "can be set" do
@@ -51,14 +45,6 @@ shared_examples "a controls config" do
       expect(subject.valid?).to eq(true)
     end
 
-    context "without a default_value" do
-      let(:default_value) { nil }
-
-      it "is valid" do
-        expect(subject.valid?).to eq(true)
-      end
-    end
-
     context "without a param" do
       let(:param) { nil }
 
@@ -66,6 +52,27 @@ shared_examples "a controls config" do
         expect(subject.valid?).to eq(false)
         expect(subject.errors.size).to eq(1)
         expect(subject.errors[:param]).to eq(["can't be blank"])
+      end
+    end
+  end
+end
+
+shared_examples "a simple controls config" do
+  include_examples "a controls config"
+
+  let(:default_value) { "OK" }
+  let(:value_from_param) { "OK" }
+
+  it "#type" do
+    expect(subject.type).to eq(type)
+  end
+
+  describe "#valid?" do
+    context "without a default_value" do
+      let(:default_value) { nil }
+
+      it "is valid" do
+        expect(subject.valid?).to eq(true)
       end
     end
   end
@@ -106,7 +113,7 @@ shared_examples "a controls config" do
   end
 
   let(:param_value) { "OK" }
-  describe "#value_from_param" do
+  describe "#value_from_params" do
     it "parses param_value" do
       expect(subject.value_from_params(subject.param => param_value)).to eq(default_value)
     end

--- a/spec/view_component/storybook/controls/array_config_spec.rb
+++ b/spec/view_component/storybook/controls/array_config_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ViewComponent::Storybook::Controls::ArrayConfig do
 
   let(:separator) { "," }
 
-  it_behaves_like "a controls config" do
+  it_behaves_like "a simple controls config" do
     let(:type) { :array }
     let(:default_value) { %w[red orange yellow] }
     let(:param_value) { "red,orange,yellow" }

--- a/spec/view_component/storybook/controls/boolean_config_spec.rb
+++ b/spec/view_component/storybook/controls/boolean_config_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe ViewComponent::Storybook::Controls::BooleanConfig do
   let(:type) { :boolean }
 
   context "with 'true' value" do
-    it_behaves_like "a controls config" do
+    it_behaves_like "a simple controls config" do
       let(:default_value) { true }
       let(:param_value) { "true" }
     end
   end
 
   context "with 'false' value" do
-    it_behaves_like "a controls config" do
+    it_behaves_like "a simple controls config" do
       let(:default_value) { false }
       let(:param_value) { "false" }
     end

--- a/spec/view_component/storybook/controls/color_config_spec.rb
+++ b/spec/view_component/storybook/controls/color_config_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe ViewComponent::Storybook::Controls::ColorConfig do
 
   let(:type) { :color }
 
-  it_behaves_like "a controls config"
+  it_behaves_like "a simple controls config"
 
   context "with :preset_color array" do
     subject { described_class.new(default_value, param: param, name: name, preset_colors: preset_colors) }
 
     let(:preset_colors) { %w[red green blue] }
 
-    it_behaves_like "a controls config" do
+    it_behaves_like "a simple controls config" do
       let(:csf_arg_type_control_overrides) { { presetColors: preset_colors } }
     end
   end

--- a/spec/view_component/storybook/controls/custom_config_spec.rb
+++ b/spec/view_component/storybook/controls/custom_config_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe ViewComponent::Storybook::Controls::CustomConfig do
+  subject do
+    described_class.new(param: param, name: name).with_value(
+      message: ViewComponent::Storybook::Controls::TextConfig.new("Hello")
+    ) do |message:|
+      message.upcase
+    end
+  end
+
+  let(:param) { :greeting }
+  let(:name) { nil }
+
+  it_behaves_like "a controls config"
+
+  describe "#valid?" do
+    it { is_expected.to be_valid }
+
+    context "with args missmatch" do
+      subject do
+        described_class.new(param: param, name: name).with_value(
+          message: ViewComponent::Storybook::Controls::TextConfig.new("Hello")
+        ) do |msg:|
+          msg.upcase
+        end
+      end
+
+      it { is_expected.to be_invalid }
+    end
+  end
+
+  describe "#to_csf_params" do
+    it "creates params" do
+      expect(subject.to_csf_params).to eq(
+        {
+          args: {
+            greeting__message: "Hello",
+          },
+          argTypes: {
+            greeting__message: { control: { type: :text }, name: "Greeting  Message" },
+          },
+        }
+      )
+    end
+
+    it "calls validate!" do
+      allow(subject).to receive(:validate!).and_raise ActiveModel::ValidationError.new(subject)
+
+      expect { subject.to_csf_params }.to raise_error ActiveModel::ValidationError
+      expect(subject).to have_received(:validate!).once
+    end
+  end
+
+  describe "#value_from_params" do
+    it "uses default value" do
+      expect(subject.value_from_params({})).to eq("HELLO")
+    end
+
+    it "parses param value" do
+      expect(subject.value_from_params(greeting__message: "Hello World!")).to eq("HELLO WORLD!")
+    end
+  end
+end

--- a/spec/view_component/storybook/controls/date_config_spec.rb
+++ b/spec/view_component/storybook/controls/date_config_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ViewComponent::Storybook::Controls::DateConfig do
   let(:type) { :date }
 
   context "with Date value" do
-    it_behaves_like "a controls config" do
+    it_behaves_like "a simple controls config" do
       let(:default_value) { Date.new(2020, 2, 15) }
       let(:param_value) { "2020-02-15T00:00:00Z" }
 
@@ -45,7 +45,7 @@ RSpec.describe ViewComponent::Storybook::Controls::DateConfig do
   end
 
   context "with DateTime value" do
-    it_behaves_like "a controls config" do
+    it_behaves_like "a simple controls config" do
       let(:default_value) { Time.utc(2020, 2, 15, 2, 30, 45).to_datetime }
       let(:param_value) { "2020-02-15T02:30:45Z" }
 
@@ -56,7 +56,7 @@ RSpec.describe ViewComponent::Storybook::Controls::DateConfig do
   end
 
   context "with Time value" do
-    it_behaves_like "a controls config" do
+    it_behaves_like "a simple controls config" do
       let(:default_value) { Time.utc(2020, 2, 15, 2, 30, 45) }
       let(:param_value) { "2020-02-15T02:30:45Z" }
 

--- a/spec/view_component/storybook/controls/number_config_spec.rb
+++ b/spec/view_component/storybook/controls/number_config_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe ViewComponent::Storybook::Controls::NumberConfig do
     context "with '#{number_type}' type" do
       subject { described_class.new(number_type, default_value, param: param, name: name) }
 
-      it_behaves_like "a controls config" do
+      it_behaves_like "a simple controls config" do
         let(:type) { number_type }
         let(:default_value) { 15 }
         let(:param_value) { "15" }
       end
 
       context "with float value" do
-        it_behaves_like "a controls config" do
+        it_behaves_like "a simple controls config" do
           let(:type) { number_type }
           let(:default_value) { 15.634 }
           let(:param_value) { "15.634" }
@@ -24,7 +24,7 @@ RSpec.describe ViewComponent::Storybook::Controls::NumberConfig do
 
         let(:number_options) { { min: 60, max: 90, step: 1 } }
 
-        it_behaves_like "a controls config" do
+        it_behaves_like "a simple controls config" do
           let(:type) { number_type }
           let(:default_value) { 15 }
           let(:param_value) { "15" }

--- a/spec/view_component/storybook/controls/object_config_spec.rb
+++ b/spec/view_component/storybook/controls/object_config_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ViewComponent::Storybook::Controls::ObjectConfig do
   let(:separator) { "," }
   let(:type) { :object }
 
-  it_behaves_like "a controls config" do
+  it_behaves_like "a simple controls config" do
     let(:default_value) { { color: "red", shape: "square" } }
     let(:param_value) { '{"color":"red","shape":"square"}' }
 
@@ -14,7 +14,7 @@ RSpec.describe ViewComponent::Storybook::Controls::ObjectConfig do
   end
 
   context "with nested value" do
-    it_behaves_like "a controls config" do
+    it_behaves_like "a simple controls config" do
       let(:default_value) { { shape: "square", options: { color: "red", size: 10 } } }
       let(:param_value) { '{"shape":"square","options":{"color":"red", "size":10}}' }
 
@@ -23,7 +23,7 @@ RSpec.describe ViewComponent::Storybook::Controls::ObjectConfig do
   end
 
   context "with an array of objects" do
-    it_behaves_like "a controls config" do
+    it_behaves_like "a simple controls config" do
       let(:default_value) { [{ shape: 'square', color: 'red' }, { shape: 'circle', color: 'green' }] }
       let(:param_value) { '[{"shape": "square", "color": "red"},{"shape": "circle", "color": "green"}]' }
 

--- a/spec/view_component/storybook/controls/options_config_spec.rb
+++ b/spec/view_component/storybook/controls/options_config_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
     context "type: #{type}" do
       let(:type) { type }
 
-      it_behaves_like "a controls config" do
+      it_behaves_like "a simple controls config" do
         subject { described_class.new(type, options, default_value, param: param, name: name) }
 
         let(:default_value) { "blue" }
@@ -19,7 +19,7 @@ RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
       context "with symbol values" do
         let(:options) { { Red: :red, Blue: :blue, Yellow: :yellow } }
 
-        it_behaves_like "a controls config" do
+        it_behaves_like "a simple controls config" do
           subject { described_class.new(type, options, default_value, param: param, name: name) }
 
           let(:default_value) { :blue }
@@ -32,7 +32,7 @@ RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
       context "with array options" do
         let(:options) { %w[red blue yellow] }
 
-        it_behaves_like "a controls config" do
+        it_behaves_like "a simple controls config" do
           subject { described_class.new(type, options, default_value, param: param, name: name) }
 
           let(:default_value) { "blue" }
@@ -45,7 +45,7 @@ RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
       context "with symbol array values" do
         let(:options) { %i[red blue yellow] }
 
-        it_behaves_like "a controls config" do
+        it_behaves_like "a simple controls config" do
           subject { described_class.new(type, options, default_value, param: param, name: name) }
 
           let(:default_value) { :blue }

--- a/spec/view_component/storybook/controls/text_config_spec.rb
+++ b/spec/view_component/storybook/controls/text_config_spec.rb
@@ -5,5 +5,5 @@ RSpec.describe ViewComponent::Storybook::Controls::TextConfig do
 
   let(:type) { :text }
 
-  it_behaves_like "a controls config"
+  it_behaves_like "a simple controls config"
 end


### PR DESCRIPTION
We were missing the specific control spec.

Refactored the shared examples for better reuse with non-simple control configs