### PR TITLE
Options controls upgrade

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,9 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Max: 10
 
+RSpec/NestedGroups:
+  Max: 5
+
 RSpec/NamedSubject:
   Enabled: false
 

--- a/lib/view_component/storybook/controls.rb
+++ b/lib/view_component/storybook/controls.rb
@@ -13,7 +13,9 @@ module ViewComponent
       autoload :BooleanConfig
       autoload :ColorConfig
       autoload :NumberConfig
+      autoload :BaseOptionsConfig
       autoload :OptionsConfig
+      autoload :MultiOptionsConfig
       autoload :ArrayConfig
       autoload :DateConfig
       autoload :ObjectConfig

--- a/lib/view_component/storybook/controls/base_options_config.rb
+++ b/lib/view_component/storybook/controls/base_options_config.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module Storybook
+    module Controls
+      class BaseOptionsConfig < SimpleControlConfig
+        attr_reader :type, :options, :labels
+
+        validates :type, :options, presence: true
+
+        def initialize(type, options, default_value, labels: nil, param: nil, name: nil)
+          super(default_value, param: param, name: name)
+          @type = type
+          @options = options
+          @labels = labels
+        end
+
+        def to_csf_params
+          super.deep_merge(argTypes: { param => { options: options } })
+        end
+
+        private
+
+        def csf_control_params
+          labels.nil? ? super : super.merge(labels: labels)
+        end
+      end
+    end
+  end
+end

--- a/lib/view_component/storybook/controls/multi_options_config.rb
+++ b/lib/view_component/storybook/controls/multi_options_config.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module Storybook
+    module Controls
+      class MultiOptionsConfig < BaseOptionsConfig
+        TYPES = %i[multi-select check inline-check].freeze
+
+        validates :type, inclusion: { in: TYPES }, unless: -> { type.nil? }
+        validate :validate_default_value, unless: -> { options.nil? || default_value.nil? }
+
+        def initialize(type, options, default_value, labels: nil, param: nil, name: nil)
+          super(type, options, Array.wrap(default_value), labels: labels, param: param, name: name)
+        end
+
+        def value_from_params(params)
+          params_value = super(params)
+
+          if params_value.is_a?(String)
+            params_value = params_value.split(',')
+            params_value = params_value.map(&:to_sym) if symbol_values
+          end
+          params_value
+        end
+
+        def to_csf_params
+          super.deep_merge(argTypes: { param => { options: options } })
+        end
+
+        private
+
+        def csf_control_params
+          labels.nil? ? super : super.merge(labels: labels)
+        end
+
+        def symbol_values
+          @symbol_values ||= default_value.first.is_a?(Symbol)
+        end
+
+        def validate_default_value
+          errors.add(:default_value, :inclusion) unless default_value.to_set <= options.to_set
+        end
+      end
+    end
+  end
+end

--- a/lib/view_component/storybook/controls/options_config.rb
+++ b/lib/view_component/storybook/controls/options_config.rb
@@ -4,25 +4,13 @@ module ViewComponent
   module Storybook
     module Controls
       class OptionsConfig < SimpleControlConfig
-        class << self
-          # support the options being a Hash or an Array. Storybook supports either.
-          def inclusion_in(config)
-            case config.options
-            when Hash
-              config.options.values
-            when Array
-              config.options
-            end
-          end
-        end
-
         TYPES = %i[select multi-select radio inline-radio check inline-check].freeze
 
         attr_reader :type, :options, :symbol_value
 
         validates :type, :options, presence: true
         validates :type, inclusion: { in: TYPES }, unless: -> { type.nil? }
-        validates :default_value, inclusion: { in: method(:inclusion_in) }, unless: -> { options.nil? || default_value.nil? }
+        validates :default_value, inclusion: { in: ->(config) { config.options } }, unless: -> { options.nil? || default_value.nil? }
 
         def initialize(type, options, default_value, param: nil, name: nil)
           super(default_value, param: param, name: name)
@@ -40,10 +28,8 @@ module ViewComponent
           end
         end
 
-        private
-
-        def csf_control_params
-          super.merge(options: options)
+        def to_csf_params
+          super.deep_merge(argTypes: { param => { options: options } })
         end
       end
     end

--- a/lib/view_component/storybook/controls/options_config.rb
+++ b/lib/view_component/storybook/controls/options_config.rb
@@ -6,16 +6,17 @@ module ViewComponent
       class OptionsConfig < SimpleControlConfig
         TYPES = %i[select multi-select radio inline-radio check inline-check].freeze
 
-        attr_reader :type, :options, :symbol_value
+        attr_reader :type, :options, :labels, :symbol_value
 
         validates :type, :options, presence: true
         validates :type, inclusion: { in: TYPES }, unless: -> { type.nil? }
         validates :default_value, inclusion: { in: ->(config) { config.options } }, unless: -> { options.nil? || default_value.nil? }
 
-        def initialize(type, options, default_value, param: nil, name: nil)
+        def initialize(type, options, default_value, labels: nil, param: nil, name: nil)
           super(default_value, param: param, name: name)
           @type = type
           @options = options
+          @labels = labels
           @symbol_value = default_value.is_a?(Symbol)
         end
 
@@ -30,6 +31,12 @@ module ViewComponent
 
         def to_csf_params
           super.deep_merge(argTypes: { param => { options: options } })
+        end
+
+        private
+
+        def csf_control_params
+          labels.nil? ? super : super.merge(labels: labels)
         end
       end
     end

--- a/lib/view_component/storybook/controls/options_config.rb
+++ b/lib/view_component/storybook/controls/options_config.rb
@@ -3,22 +3,11 @@
 module ViewComponent
   module Storybook
     module Controls
-      class OptionsConfig < SimpleControlConfig
+      class OptionsConfig < BaseOptionsConfig
         TYPES = %i[select multi-select radio inline-radio check inline-check].freeze
 
-        attr_reader :type, :options, :labels, :symbol_value
-
-        validates :type, :options, presence: true
         validates :type, inclusion: { in: TYPES }, unless: -> { type.nil? }
         validates :default_value, inclusion: { in: ->(config) { config.options } }, unless: -> { options.nil? || default_value.nil? }
-
-        def initialize(type, options, default_value, labels: nil, param: nil, name: nil)
-          super(default_value, param: param, name: name)
-          @type = type
-          @options = options
-          @labels = labels
-          @symbol_value = default_value.is_a?(Symbol)
-        end
 
         def value_from_params(params)
           params_value = super(params)
@@ -37,6 +26,10 @@ module ViewComponent
 
         def csf_control_params
           labels.nil? ? super : super.merge(labels: labels)
+        end
+
+        def symbol_value
+          @symbol_value ||= default_value.is_a?(Symbol)
         end
       end
     end

--- a/lib/view_component/storybook/dsl/controls_dsl.rb
+++ b/lib/view_component/storybook/dsl/controls_dsl.rb
@@ -33,7 +33,7 @@ module ViewComponent
         end
 
         def multi_select(options, default_value, labels: nil)
-          Controls::OptionsConfig.new(:'multi-select', options, default_value, labels: labels)
+          Controls::MultiOptionsConfig.new(:'multi-select', options, default_value, labels: labels)
         end
 
         def radio(options, default_value, labels: nil)
@@ -45,11 +45,11 @@ module ViewComponent
         end
 
         def check(options, default_value, labels: nil)
-          Controls::OptionsConfig.new(:check, options, default_value, labels: labels)
+          Controls::MultiOptionsConfig.new(:check, options, default_value, labels: labels)
         end
 
         def inline_check(options, default_value)
-          Controls::OptionsConfig.new(:'inline-check', options, default_value)
+          Controls::MultiOptionsConfig.new(:'inline-check', options, default_value)
         end
 
         def array(default_value, separator = ",")

--- a/lib/view_component/storybook/dsl/controls_dsl.rb
+++ b/lib/view_component/storybook/dsl/controls_dsl.rb
@@ -28,24 +28,24 @@ module ViewComponent
           Controls::ObjectConfig.new(default_value)
         end
 
-        def select(options, default_value)
-          Controls::OptionsConfig.new(:select, options, default_value)
+        def select(options, default_value, labels: nil)
+          Controls::OptionsConfig.new(:select, options, default_value, labels: labels)
         end
 
-        def multi_select(options, default_value)
-          Controls::OptionsConfig.new(:'multi-select', options, default_value)
+        def multi_select(options, default_value, labels: nil)
+          Controls::OptionsConfig.new(:'multi-select', options, default_value, labels: labels)
         end
 
-        def radio(options, default_value)
-          Controls::OptionsConfig.new(:radio, options, default_value)
+        def radio(options, default_value, labels: nil)
+          Controls::OptionsConfig.new(:radio, options, default_value, labels: labels)
         end
 
-        def inline_radio(options, default_value)
-          Controls::OptionsConfig.new(:'inline-radio', options, default_value)
+        def inline_radio(options, default_value, labels: nil)
+          Controls::OptionsConfig.new(:'inline-radio', options, default_value, labels: labels)
         end
 
-        def check(options, default_value)
-          Controls::OptionsConfig.new(:check, options, default_value)
+        def check(options, default_value, labels: nil)
+          Controls::OptionsConfig.new(:check, options, default_value, labels: labels)
         end
 
         def inline_check(options, default_value)

--- a/spec/dummy/test/components/stories/kitchen_sink_component_stories.rb
+++ b/spec/dummy/test/components/stories/kitchen_sink_component_stories.rb
@@ -10,7 +10,11 @@ class KitchenSinkComponentStories < ViewComponent::Storybook::Stories
       number_pets: number(2),
       sports: array(%w[football baseball]),
       favorite_food: select(["Burgers", "Hot Dog", "Ice Cream", "Pizza"], "Ice Cream"),
-      mood: radio(["Happy", "Sad", "Angry", "Content"], "Happy"),
+      mood: radio(
+        [:happy, :sad, :angry, :content],
+        :happy,
+        labels: { happy: "Happy", sad: "Sad", angry: "Angry", content: "Content" }
+      ),
       other_things: object({ hair: "Brown", eyes: "Blue" })
     )
   end

--- a/spec/dummy/test/components/stories/kitchen_sink_component_stories.rb
+++ b/spec/dummy/test/components/stories/kitchen_sink_component_stories.rb
@@ -9,8 +9,8 @@ class KitchenSinkComponentStories < ViewComponent::Storybook::Stories
       like_people: boolean(true),
       number_pets: number(2),
       sports: array(%w[football baseball]),
-      favorite_food: select({ hot_dog: "Hot Dog", pizza: "Pizza", burgers: "Burgers", ice_cream: "Ice Cream" }, "Ice Cream"),
-      mood: radio({ happy: "Happy", sad: "Sad", angry: "Angry", content: "Content" }, "Happy"),
+      favorite_food: select(["Burgers", "Hot Dog", "Ice Cream", "Pizza"], "Ice Cream"),
+      mood: radio(["Happy", "Sad", "Angry", "Content"], "Happy"),
       other_things: object({ hair: "Brown", eyes: "Blue" })
     )
   end

--- a/spec/view_component/storybook/controls/options_config_spec.rb
+++ b/spec/view_component/storybook/controls/options_config_spec.rb
@@ -1,33 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
-  let(:options) { { Red: "red", Blue: "blue", Yellow: "yellow" } }
-
   described_class::TYPES.each do |type|
     context "type: #{type}" do
       let(:type) { type }
-
-      it_behaves_like "a simple controls config" do
-        subject { described_class.new(type, options, default_value, param: param, name: name) }
-
-        let(:default_value) { "blue" }
-        let(:param_value) { "blue" }
-
-        let(:csf_arg_type_control_overrides) { { options: options } }
-      end
-
-      context "with symbol values" do
-        let(:options) { { Red: :red, Blue: :blue, Yellow: :yellow } }
-
-        it_behaves_like "a simple controls config" do
-          subject { described_class.new(type, options, default_value, param: param, name: name) }
-
-          let(:default_value) { :blue }
-          let(:param_value) { "blue" }
-
-          let(:csf_arg_type_control_overrides) { { options: options } }
-        end
-      end
 
       context "with array options" do
         let(:options) { %w[red blue yellow] }
@@ -38,7 +14,16 @@ RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
           let(:default_value) { "blue" }
           let(:param_value) { "blue" }
 
-          let(:csf_arg_type_control_overrides) { { options: options } }
+          let(:expected_csf_params) do
+            {
+              args: {
+                button_text: expected_csf_value,
+              },
+              argTypes: {
+                button_text: { control: { type: type }, name: "Button Text", options: options },
+              },
+            }
+          end
         end
       end
 
@@ -51,13 +36,24 @@ RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
           let(:default_value) { :blue }
           let(:param_value) { "blue" }
 
-          let(:csf_arg_type_control_overrides) { { options: options } }
+          let(:expected_csf_params) do
+            {
+              args: {
+                button_text: expected_csf_value,
+              },
+              argTypes: {
+                button_text: { control: { type: type }, name: "Button Text", options: options },
+              },
+            }
+          end
         end
       end
     end
   end
 
   describe "#valid?" do
+    let(:options) { %w[red blue yellow] }
+
     it "invalid without type" do
       subject = described_class.new(nil, options, "blue", param: :button_text)
 
@@ -74,7 +70,7 @@ RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
       expect(subject.errors[:type]).to eq(["is not included in the list"])
     end
 
-    it "invalid with value not in the options hash" do
+    it "invalid with value not in the options list" do
       subject = described_class.new(:radio, options, "green", param: :button_text)
 
       expect(subject.valid?).to eq(false)
@@ -82,23 +78,11 @@ RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
       expect(subject.errors[:default_value]).to eq(["is not included in the list"])
     end
 
-    context "with array options" do
-      let(:options) { %w[red blue yellow] }
+    it "valid with nil default_value provided its in the options list" do
+      options << nil
+      subject = described_class.new(:radio, options, nil, param: :button_text)
 
-      it "invalid with value not in the options list" do
-        subject = described_class.new(:radio, options, "green", param: :button_text)
-
-        expect(subject.valid?).to eq(false)
-        expect(subject.errors.size).to eq(1)
-        expect(subject.errors[:default_value]).to eq(["is not included in the list"])
-      end
-
-      it "valid with nil default_value provided its in the options list" do
-        options << nil
-        subject = described_class.new(:radio, options, nil, param: :button_text)
-
-        expect(subject.valid?).to eq(true)
-      end
+      expect(subject.valid?).to eq(true)
     end
   end
 end

--- a/spec/view_component/storybook/controls/options_config_spec.rb
+++ b/spec/view_component/storybook/controls/options_config_spec.rb
@@ -25,6 +25,42 @@ RSpec.describe ViewComponent::Storybook::Controls::OptionsConfig do
             }
           end
         end
+
+        context "with labels" do
+          it_behaves_like "a simple controls config" do
+            subject do
+              described_class.new(
+                type,
+                options,
+                default_value,
+                labels: { "red" => "Red", "blue" => "Blue", "yellow" => "Yellow" },
+                param: param,
+                name: name
+              )
+            end
+
+            let(:default_value) { "blue" }
+            let(:param_value) { "blue" }
+
+            let(:expected_csf_params) do
+              {
+                args: {
+                  button_text: expected_csf_value,
+                },
+                argTypes: {
+                  button_text: {
+                    control: {
+                      type: type,
+                      labels: { "red" => "Red", "blue" => "Blue", "yellow" => "Yellow" }
+                    },
+                    name: "Button Text",
+                    options: options
+                  },
+                },
+              }
+            end
+          end
+        end
       end
 
       context "with symbol array values" do

--- a/spec/view_component/storybook/dsl/controls_dsl_spec.rb
+++ b/spec/view_component/storybook/dsl/controls_dsl_spec.rb
@@ -109,54 +109,70 @@ RSpec.describe ViewComponent::Storybook::Dsl::ControlsDsl do
                      }
   end
 
-  %w[select multi-select radio inline-radio check inline-check].each do |type|
+  %w[select radio inline-radio].each do |type|
     dsl_method = type.underscore
 
     describe "##{dsl_method}" do
-      subject { send(dsl_method, { hot_dog: "Hot Dog", pizza: "Pizza" }, "Pizza") }
+      subject { send(dsl_method, [:hot_dog, :pizza], :pizza) }
 
       include_examples "has controls attributes",
                        {
                          class: ViewComponent::Storybook::Controls::OptionsConfig,
                          type: type.to_sym,
-                         default_value: "Pizza",
-                         options: { hot_dog: "Hot Dog", pizza: "Pizza" }
+                         default_value: :pizza,
+                         options: [:hot_dog, :pizza]
                        }
     end
+  end
 
-    describe "#custom" do
-      subject do
-        custom(first_name: "J.R.R.", last_name: "Tolkien") do |first_name:, last_name:|
-          Author.new(first_name: first_name, last_name: last_name).full_name
-        end
-      end
+  %w[multi-select check inline-check].each do |type|
+    dsl_method = type.underscore
+
+    describe "##{dsl_method}" do
+      subject { send(dsl_method, [:hot_dog, :pizza], [:pizza]) }
 
       include_examples "has controls attributes",
                        {
-                         class: ViewComponent::Storybook::Controls::CustomConfig
+                         class: ViewComponent::Storybook::Controls::MultiOptionsConfig,
+                         type: type.to_sym,
+                         default_value: [:pizza],
+                         options: [:hot_dog, :pizza]
                        }
+    end
+  end
 
-      it "returns cutom value from params" do
-        from_params = subject.value_from_params({})
-        expect(from_params).to eq("J.R.R. Tolkien")
+  describe "#custom" do
+    subject do
+      custom(first_name: "J.R.R.", last_name: "Tolkien") do |first_name:, last_name:|
+        Author.new(first_name: first_name, last_name: last_name).full_name
       end
     end
 
-    describe "#klazz" do
-      subject do
-        klazz(Author, first_name: "J.R.R.", last_name: "Tolkien")
-      end
+    include_examples "has controls attributes",
+                     {
+                       class: ViewComponent::Storybook::Controls::CustomConfig
+                     }
 
-      include_examples "has controls attributes",
-                       {
-                         class: ViewComponent::Storybook::Controls::CustomConfig
-                       }
+    it "returns cutom value from params" do
+      from_params = subject.value_from_params({})
+      expect(from_params).to eq("J.R.R. Tolkien")
+    end
+  end
 
-      it "returns cutom value from params" do
-        from_params = subject.value_from_params({})
-        expect(from_params).to be_a(Author)
-        expect(from_params.full_name).to eq("J.R.R. Tolkien")
-      end
+  describe "#klazz" do
+    subject do
+      klazz(Author, first_name: "J.R.R.", last_name: "Tolkien")
+    end
+
+    include_examples "has controls attributes",
+                     {
+                       class: ViewComponent::Storybook::Controls::CustomConfig
+                     }
+
+    it "returns cutom value from params" do
+      from_params = subject.value_from_params({})
+      expect(from_params).to be_a(Author)
+      expect(from_params.full_name).to eq("J.R.R. Tolkien")
     end
   end
 end

--- a/spec/view_component/storybook/stories_controller_spec.rb
+++ b/spec/view_component/storybook/stories_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe ViewComponent::Storybook::StoriesController, type: :request do
           <p>I have 2 pets</p>
           <p>I like to watch football and baseball</p>
           <p>My favorite food is Ice Cream</p>
-          <p>I'm feeling Happy</p>
+          <p>I'm feeling happy</p>
           <p>Other things about me {"hair":"Brown","eyes":"Blue"}</p>
         </div>
       HTML

--- a/spec/view_component/storybook/stories_spec.rb
+++ b/spec/view_component/storybook/stories_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe ViewComponent::Storybook::Stories do
               number_pets: 2,
               sports: %w[football baseball],
               favorite_food: "Ice Cream",
-              mood: "Happy",
+              mood: :happy,
               other_things: { eyes: "Blue", hair: "Brown" }
 
             },
@@ -235,7 +235,6 @@ RSpec.describe ViewComponent::Storybook::Stories do
               favorite_food: {
                 control: {
                   type: :select,
-                  # options: { burgers: "Burgers", hot_dog: "Hot Dog", ice_cream: "Ice Cream", pizza: "Pizza" }
                 },
                 name: "Favorite Food",
                 options: ["Burgers", "Hot Dog", "Ice Cream", "Pizza"]
@@ -243,10 +242,10 @@ RSpec.describe ViewComponent::Storybook::Stories do
               mood: {
                 control: {
                   type: :radio,
-                  # options: { happy: "Happy", sad: "Sad", angry: "Angry", content: "Content" },
+                  labels: { happy: "Happy", sad: "Sad", angry: "Angry", content: "Content" },
                 },
                 name: "Mood",
-                options: ["Happy", "Sad", "Angry", "Content"]
+                options: [:happy, :sad, :angry, :content]
               },
               other_things: { control: { type: :object }, name: "Other Things" },
             }

--- a/spec/view_component/storybook/stories_spec.rb
+++ b/spec/view_component/storybook/stories_spec.rb
@@ -235,16 +235,18 @@ RSpec.describe ViewComponent::Storybook::Stories do
               favorite_food: {
                 control: {
                   type: :select,
-                  options: { burgers: "Burgers", hot_dog: "Hot Dog", ice_cream: "Ice Cream", pizza: "Pizza" }
+                  # options: { burgers: "Burgers", hot_dog: "Hot Dog", ice_cream: "Ice Cream", pizza: "Pizza" }
                 },
                 name: "Favorite Food",
+                options: ["Burgers", "Hot Dog", "Ice Cream", "Pizza"]
               },
               mood: {
                 control: {
                   type: :radio,
-                  options: { happy: "Happy", sad: "Sad", angry: "Angry", content: "Content" },
+                  # options: { happy: "Happy", sad: "Sad", angry: "Angry", content: "Content" },
                 },
-                name: "Mood"
+                name: "Mood",
+                options: ["Happy", "Sad", "Angry", "Content"]
               },
               other_things: { control: { type: :object }, name: "Other Things" },
             }


### PR DESCRIPTION
Storybook [options controls changed](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-controloptions) a while back this supports the new format 
Also adds new support for multi select options having an array default value and return type