### PR TITLE
Fix ArgumentError in write_stories_json rake task

### DIFF
--- a/lib/view_component/storybook/tasks/write_stories_json.rake
+++ b/lib/view_component/storybook/tasks/write_stories_json.rake
@@ -12,7 +12,7 @@ namespace :view_component_storybook do
       exceptions << e
     end
 
-    raise StandardError, exceptions.map(:message).join(", ") if exceptions.present?
+    raise StandardError, exceptions.map(&:message).join(", ") if exceptions.present?
 
     puts "Done"
   end


### PR DESCRIPTION
In `write_stories_json.rake`, `map` was being passed a symbol rather than a proc.