### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -16,7 +16,7 @@ nav_order: 1
    gem "view_component", require: "view_component/engine"
    gem "view_component_storybook", require: "view_component/storybook/engine"
    ```
-1. In`.gitignore`, add:
+2. In`.gitignore`, add:
    ```text
    **/*.stories.json
    ```

--- a/docs/guide/stories.md
+++ b/docs/guide/stories.md
@@ -63,7 +63,7 @@ Components are rendered in the default application layout. The layout for a set 
 ```ruby
 # test/components/stories/header_componeont_stories.rb
 class HeaderComponentStories < ViewComponent::Storybook::Stories
-  layout :desktop
+  layout 'desktop'
   
   story :h1 do
     constructor("h1")


### PR DESCRIPTION
Just a few minor fixes to the documentation:

- fix naming of `stories_route`
- add extra line indicating that this gem itself should be installed
- add missing Storybook JS dependency
- fix `layout` syntax