### PR TITLE
Fix install instructions, plus simplify require

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -14,10 +14,7 @@ nav_order: 1
 1. In `Gemfile`, add:
    ```ruby
    gem "view_component", require: "view_component/engine"
-   ```
-1. In `config/application.rb`, add: 
-   ```ruby
-   require "view_component/storybook/engine"
+   gem "view_component_storybook", require: "view_component/storybook/engine"
    ```
 1. In`.gitignore`, add:
    ```text


### PR DESCRIPTION
I noticed that the install instruction do not provide actual instructions for installing "view_component_storybook", only "view_component", so this fix will change this.

Also, it is possible automatically require `view_component/storybook/engine` by using a "require" param in the Gemfile, without making modifications to the config/application.rb. It is more clean, specially when updating Rails, because the update task will often try to touch this file.