### PR TITLE
Fix documentation rendering slot collections

### DIFF
--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -112,7 +112,7 @@ end
 # test/components/stories/navigation_component_stories.rb
 class NavigationComponentStories < ViewComponent::Storybook::Stories
   story :nav do
-    links(array(
+    links(
       [
         { name: "Home", href: "/" },
         { name: "Pricing", href: "/pricing" },


### PR DESCRIPTION
Using the `array` control when rendering a slot collection doesn't seem to work for me, I keep getting an error about missing params when generating the json file.

If it does work and I'm doing something wrong then you just need to add a closing bracking to the `array(` method call.