### PR TITLE
Update “Getting Started” with missing (?) step in `config/application.rb`

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -20,6 +20,11 @@ nav_order: 1
    ```text
    **/*.stories.json
    ```
+3. In `config/application.rb`, add:
+   ```ruby
+   require 'view_component'
+   require 'view_component/storybook'
+   ```
 
 
 ### Storybook Installation


### PR DESCRIPTION
I just updated to 0.11.0 and had issues with removing the `require 'view_component/storybook/engine` bit as per the deprecation message.

I was getting this error when running `rake view_component_storybook:write_stories_json`:

```
NoMethodError: undefined method `view_component_storybook' for #<Rails::Application::Configuration:0x000000012a37bcb8>
```

Per https://github.com/jonspalmer/view_component_storybook/commit/bf741361647a646d21c4f3f75dd75991fd7ea65e#r67181744, adding `require 'view_component'` and `require 'view_component/storybook'` fixed the issue.